### PR TITLE
test: add mock-based E2E testing mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,12 @@ release:
 # E2E Testing
 # =============================================================================
 
-# Start E2E test environment
+# Run Playwright E2E tests in mock mode (no Docker required)
+# This is the default and recommended way to run E2E tests locally
+e2e-mock:
+	cd $(FRONTEND_DIR) && npm test
+
+# Start E2E test environment (Docker)
 e2e-up:
 	docker compose -f docker-compose.e2e.yml up -d --wait
 	@echo "Waiting for services..."
@@ -176,14 +181,17 @@ e2e-down:
 e2e-api:
 	uv run pytest tests/e2e/ -m e2e -v
 
-# Run Playwright E2E tests (requires e2e-up first)
-e2e-playwright:
-	cd $(FRONTEND_DIR) && npm test
+# Run Playwright E2E tests against real Docker backend
+e2e-playwright-real:
+	cd $(FRONTEND_DIR) && E2E_MODE=real PLAYWRIGHT_BASE_URL=http://localhost:8000 npm test
 
-# Run all E2E tests (ensures cleanup on failure)
+# Run all E2E tests against Docker (full integration)
 e2e:
 	$(MAKE) e2e-up
-	$(MAKE) e2e-api && $(MAKE) e2e-playwright; \
+	$(MAKE) e2e-api && $(MAKE) e2e-playwright-real; \
 	status=$$?; \
 	$(MAKE) e2e-down; \
 	exit $$status
+
+# Quick E2E alias (mock mode, no Docker)
+e2e-quick: e2e-mock

--- a/src/stemtrace/server/ui/frontend/tests/fixtures/mock-api.ts
+++ b/src/stemtrace/server/ui/frontend/tests/fixtures/mock-api.ts
@@ -1,0 +1,362 @@
+/**
+ * Mock API setup for Playwright tests.
+ *
+ * This intercepts API calls and returns mock data, allowing tests
+ * to run without Docker or a real backend.
+ *
+ * Usage:
+ *   import { setupMockApi, MockApiContext } from './fixtures/mock-api'
+ *
+ *   test('my test', async ({ page }) => {
+ *     const mockApi = await setupMockApi(page)
+ *     mockApi.addTask(createSuccessTask('my.task', 42))
+ *     await page.goto('/')
+ *     // ... assertions
+ *   })
+ */
+
+import type { Page, Route } from '@playwright/test'
+
+import { createSuccessTask, DEFAULT_REGISTRY, DEFAULT_TASKS, type MockTask } from './mock-data'
+
+export interface MockApiContext {
+  /** All tasks in the mock store */
+  tasks: MockTask[]
+
+  /** Add a task to the mock store */
+  addTask: (task: MockTask) => void
+
+  /** Add multiple tasks */
+  addTasks: (tasks: MockTask[]) => void
+
+  /** Clear all tasks */
+  clearTasks: () => void
+
+  /** Reset to default tasks */
+  resetToDefaults: () => void
+
+  /** Get a task by ID */
+  getTask: (taskId: string) => MockTask | undefined
+
+  /** Get root tasks (for graphs list) */
+  getRootTasks: () => MockTask[]
+
+  /** Stop intercepting (cleanup) */
+  teardown: () => Promise<void>
+}
+
+/**
+ * Build nodes map for graph response from tasks
+ */
+function buildNodesMap(tasks: MockTask[], rootId: string): Record<string, unknown> {
+  const graphTasks = tasks.filter((t) => t.root_id === rootId)
+  const nodes: Record<string, unknown> = {}
+
+  for (const task of graphTasks) {
+    nodes[task.task_id] = {
+      task_id: task.task_id,
+      name: task.name,
+      state: task.state,
+      parent_id: task.parent_id,
+      root_id: task.root_id,
+      node_type: task.node_type,
+      group_id: task.group_id,
+      chord_id: task.chord_id,
+      children: task.children,
+      events: task.events,
+      first_seen: task.first_seen,
+      last_updated: task.last_updated,
+      duration_ms: task.duration_ms,
+    }
+  }
+
+  return nodes
+}
+
+/**
+ * Set up mock API routes on a Playwright page.
+ *
+ * @param page - Playwright page instance
+ * @param options - Configuration options
+ * @returns MockApiContext for controlling mock data
+ */
+export async function setupMockApi(
+  page: Page,
+  options: {
+    /** Start with default mock tasks */
+    useDefaults?: boolean
+    /** Base URL path for API (default: /api for dev mode, /stemtrace/api for production) */
+    apiPath?: string
+  } = {},
+): Promise<MockApiContext> {
+  // In dev mode (Vite), frontend uses /api which gets proxied
+  // In production/Docker, it's /stemtrace/api
+  // For mock mode, we intercept /api since that's what the frontend calls
+  const { useDefaults = true, apiPath = '/api' } = options
+
+  // Mutable task store
+  let tasks: MockTask[] = useDefaults ? [...DEFAULT_TASKS] : []
+
+  const context: MockApiContext = {
+    get tasks() {
+      return tasks
+    },
+
+    addTask(task: MockTask) {
+      tasks.push(task)
+    },
+
+    addTasks(newTasks: MockTask[]) {
+      tasks.push(...newTasks)
+    },
+
+    clearTasks() {
+      tasks = []
+    },
+
+    resetToDefaults() {
+      tasks = [...DEFAULT_TASKS]
+    },
+
+    getTask(taskId: string) {
+      return tasks.find((t) => t.task_id === taskId)
+    },
+
+    getRootTasks() {
+      // Root tasks are those where task_id === root_id
+      return tasks.filter((t) => t.task_id === t.root_id)
+    },
+
+    async teardown() {
+      await page.unrouteAll()
+    },
+  }
+
+  // === Route handlers ===
+  // Note: Routes are matched in order of registration, so register more specific patterns first
+
+  // Helper to serialize task to API format
+  const serializeTask = (t: MockTask) => ({
+    task_id: t.task_id,
+    name: t.name,
+    state: t.state,
+    parent_id: t.parent_id,
+    root_id: t.root_id,
+    node_type: t.node_type,
+    group_id: t.group_id,
+    chord_id: t.chord_id,
+    children: t.children,
+    events: t.events,
+    first_seen: t.first_seen,
+    last_updated: t.last_updated,
+    duration_ms: t.duration_ms,
+  })
+
+  // Health endpoint (use regex like other routes)
+  await page.route(new RegExp(`${apiPath}/health`), async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'ok',
+        version: '0.1.0',
+        consumer_running: true,
+        websocket_connections: 0,
+        node_count: tasks.length,
+      }),
+    })
+  })
+
+  // Registry: GET /tasks/registry (more specific, register first)
+  await page.route(new RegExp(`${apiPath}/tasks/registry`), async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        tasks: DEFAULT_REGISTRY,
+        total: DEFAULT_REGISTRY.length,
+      }),
+    })
+  })
+
+  // Task detail: GET /tasks/:taskId (register before tasks list)
+  await page.route(new RegExp(`${apiPath}/tasks/[^/]+$`), async (route: Route) => {
+    const url = route.request().url()
+
+    // Skip registry endpoint - use fallback() to pass to next route handler, not continue() which goes to network
+    if (url.includes('/tasks/registry')) {
+      await route.fallback()
+      return
+    }
+
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    const taskId = url.split('/tasks/').pop()?.split('?')[0]
+    const task = tasks.find((t) => t.task_id === taskId)
+
+    if (!task) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Task not found' }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        task: serializeTask(task),
+        children: [],
+      }),
+    })
+  })
+
+  // Tasks list: GET /tasks (matches /api/tasks and /api/tasks?query=...)
+  await page.route(new RegExp(`${apiPath}/tasks(\\?|$)`), async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    const url = new URL(route.request().url())
+    const state = url.searchParams.get('state')
+    const name = url.searchParams.get('name')
+    const limit = Number.parseInt(url.searchParams.get('limit') || '50', 10)
+    const offset = Number.parseInt(url.searchParams.get('offset') || '0', 10)
+
+    let filtered = [...tasks]
+
+    if (state) {
+      filtered = filtered.filter((t) => t.state === state)
+    }
+    if (name) {
+      filtered = filtered.filter((t) => t.name.includes(name))
+    }
+
+    const paginated = filtered.slice(offset, offset + limit)
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        tasks: paginated.map(serializeTask),
+        total: filtered.length,
+        limit,
+        offset,
+      }),
+    })
+  })
+
+  // Graph detail: GET /graphs/:rootId (register before graphs list)
+  await page.route(new RegExp(`${apiPath}/graphs/[^/]+`), async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    const url = route.request().url()
+    const rootId = url.split('/graphs/').pop()?.split('?')[0]
+
+    if (!rootId) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Graph not found' }),
+      })
+      return
+    }
+
+    const nodes = buildNodesMap(tasks, rootId)
+
+    if (Object.keys(nodes).length === 0) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Graph not found' }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        root_id: rootId,
+        nodes,
+      }),
+    })
+  })
+
+  // Graphs list: GET /graphs (matches /api/graphs and /api/graphs?query=...)
+  await page.route(new RegExp(`${apiPath}/graphs(\\?|$)`), async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue()
+      return
+    }
+
+    const rootTasks = context.getRootTasks()
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        graphs: rootTasks.map((t) => ({
+          task_id: t.task_id,
+          name: t.name,
+          state: t.state,
+          node_type: t.node_type,
+          group_id: t.group_id,
+          chord_id: t.chord_id,
+          parent_id: t.parent_id,
+          children: t.children,
+          first_seen: t.first_seen,
+          last_updated: t.last_updated,
+          duration_ms: t.duration_ms,
+        })),
+        total: rootTasks.length,
+        limit: 50,
+        offset: 0,
+      }),
+    })
+  })
+
+  // WebSocket - just acknowledge connection (no real streaming)
+  // Playwright doesn't easily mock WebSockets, so we'll skip real WS testing
+  // in mock mode
+
+  return context
+}
+
+/**
+ * Create a pre-configured mock API with specific scenarios
+ */
+export const mockScenarios = {
+  /** Empty state - no tasks */
+  empty: async (page: Page) => setupMockApi(page, { useDefaults: false }),
+
+  /** Only simple tasks, no workflows */
+  simpleTasks: async (page: Page) => {
+    const ctx = await setupMockApi(page, { useDefaults: false })
+    ctx.addTask(createSuccessTask('tasks.add', 5))
+    ctx.addTask(createSuccessTask('tasks.multiply', 20))
+    return ctx
+  },
+
+  /** Full default data set */
+  defaults: async (page: Page) => setupMockApi(page, { useDefaults: true }),
+}

--- a/src/stemtrace/server/ui/frontend/tests/fixtures/mock-data.ts
+++ b/src/stemtrace/server/ui/frontend/tests/fixtures/mock-data.ts
@@ -1,0 +1,429 @@
+/**
+ * Mock data for Playwright E2E tests.
+ *
+ * This allows tests to run without Docker by mocking API responses.
+ */
+
+export interface MockTask {
+  task_id: string
+  name: string
+  state: string
+  parent_id: string | null
+  root_id: string
+  node_type: 'TASK' | 'GROUP' | 'CHORD'
+  group_id: string | null
+  chord_id: string | null
+  events: MockEvent[]
+  children: string[]
+  first_seen: string | null
+  last_updated: string | null
+  duration_ms: number | null
+}
+
+export interface MockEvent {
+  task_id: string
+  name: string
+  state: string
+  timestamp: string
+  parent_id: string | null
+  root_id: string
+  group_id: string | null
+  args: unknown[] | null
+  kwargs: Record<string, unknown> | null
+  result: unknown | null
+  exception: string | null
+  traceback: string | null
+  retry_count: number
+}
+
+/**
+ * Generate a UUID-like task ID
+ */
+export function generateTaskId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+/**
+ * Create a mock event for a task
+ */
+export function createMockEvent(
+  task_id: string,
+  name: string,
+  state: string,
+  options: Partial<MockEvent> = {},
+): MockEvent {
+  return {
+    task_id,
+    name,
+    state,
+    timestamp: new Date().toISOString(),
+    parent_id: null,
+    root_id: task_id,
+    group_id: null,
+    args: null,
+    kwargs: null,
+    result: null,
+    exception: null,
+    traceback: null,
+    retry_count: 0,
+    ...options,
+  }
+}
+
+/**
+ * Create a simple successful task
+ */
+export function createSuccessTask(name: string, result: unknown = null): MockTask {
+  const task_id = generateTaskId()
+  const now = new Date()
+  const startTime = new Date(now.getTime() - 1000) // 1 second ago
+  return {
+    task_id,
+    name,
+    state: 'SUCCESS',
+    parent_id: null,
+    root_id: task_id,
+    node_type: 'TASK',
+    group_id: null,
+    chord_id: null,
+    children: [],
+    first_seen: startTime.toISOString(),
+    last_updated: now.toISOString(),
+    duration_ms: 1000,
+    events: [
+      createMockEvent(task_id, name, 'PENDING', { args: [1, 2] }),
+      createMockEvent(task_id, name, 'STARTED'),
+      createMockEvent(task_id, name, 'SUCCESS', { result }),
+    ],
+  }
+}
+
+/**
+ * Create a failed task with exception
+ */
+export function createFailedTask(name: string, exception: string, traceback: string): MockTask {
+  const task_id = generateTaskId()
+  const now = new Date()
+  const startTime = new Date(now.getTime() - 500)
+  return {
+    task_id,
+    name,
+    state: 'FAILURE',
+    parent_id: null,
+    root_id: task_id,
+    node_type: 'TASK',
+    group_id: null,
+    chord_id: null,
+    children: [],
+    first_seen: startTime.toISOString(),
+    last_updated: now.toISOString(),
+    duration_ms: 500,
+    events: [
+      createMockEvent(task_id, name, 'PENDING'),
+      createMockEvent(task_id, name, 'STARTED'),
+      createMockEvent(task_id, name, 'FAILURE', { exception, traceback }),
+    ],
+  }
+}
+
+/**
+ * Create a task chain: parent -> child -> grandchild
+ */
+export function createChain(baseName: string, length: number): MockTask[] {
+  const tasks: MockTask[] = []
+  let parent_id: string | null = null
+  const root_id = generateTaskId()
+
+  const now = new Date()
+  for (let i = 0; i < length; i++) {
+    const task_id = i === 0 ? root_id : generateTaskId()
+    const startTime = new Date(now.getTime() - (length - i) * 1000)
+    const task: MockTask = {
+      task_id,
+      name: `${baseName}.step_${i + 1}`,
+      state: 'SUCCESS',
+      parent_id,
+      root_id,
+      node_type: 'TASK',
+      group_id: null,
+      chord_id: null,
+      children: [],
+      first_seen: startTime.toISOString(),
+      last_updated: now.toISOString(),
+      duration_ms: 500,
+      events: [
+        createMockEvent(task_id, `${baseName}.step_${i + 1}`, 'PENDING', {
+          parent_id,
+          root_id,
+        }),
+        createMockEvent(task_id, `${baseName}.step_${i + 1}`, 'SUCCESS', {
+          parent_id,
+          root_id,
+          result: { step: i + 1 },
+        }),
+      ],
+    }
+
+    // Link parent to child
+    if (tasks.length > 0) {
+      tasks[tasks.length - 1].children.push(task_id)
+    }
+
+    tasks.push(task)
+    parent_id = task_id
+  }
+
+  return tasks
+}
+
+/**
+ * Create a GROUP with member tasks
+ */
+export function createGroup(
+  memberCount: number,
+  options: { withCallback?: boolean } = {},
+): MockTask[] {
+  const group_id = generateTaskId()
+  const now = new Date()
+  const startTime = new Date(now.getTime() - 2000)
+
+  const groupNode: MockTask = {
+    task_id: `group:${group_id}`,
+    name: `group:${group_id.slice(0, 8)}`,
+    state: 'SUCCESS',
+    parent_id: null,
+    root_id: `group:${group_id}`,
+    node_type: options.withCallback ? 'CHORD' : 'GROUP',
+    group_id,
+    chord_id: null,
+    children: [],
+    first_seen: startTime.toISOString(),
+    last_updated: now.toISOString(),
+    duration_ms: 2000,
+    events: [], // Synthetic nodes have no events
+  }
+
+  const members: MockTask[] = []
+  for (let i = 0; i < memberCount; i++) {
+    const task_id = generateTaskId()
+    const task: MockTask = {
+      task_id,
+      name: 'tasks.process_item',
+      state: 'SUCCESS',
+      parent_id: null, // Members have group_id, not parent_id
+      root_id: `group:${group_id}`,
+      node_type: 'TASK',
+      group_id,
+      chord_id: null,
+      children: [],
+      first_seen: startTime.toISOString(),
+      last_updated: now.toISOString(),
+      duration_ms: 500,
+      events: [
+        createMockEvent(task_id, 'tasks.process_item', 'PENDING', {
+          group_id,
+          root_id: `group:${group_id}`,
+          args: [i],
+        }),
+        createMockEvent(task_id, 'tasks.process_item', 'SUCCESS', {
+          group_id,
+          root_id: `group:${group_id}`,
+          result: i * 2,
+        }),
+      ],
+    }
+    members.push(task)
+    groupNode.children.push(task_id)
+  }
+
+  const allTasks = [groupNode, ...members]
+
+  // Add callback if requested
+  if (options.withCallback) {
+    const callback_id = generateTaskId()
+    const callback: MockTask = {
+      task_id: callback_id,
+      name: 'tasks.aggregate',
+      state: 'SUCCESS',
+      parent_id: `group:${group_id}`,
+      root_id: `group:${group_id}`,
+      node_type: 'TASK',
+      group_id: null,
+      chord_id: null,
+      children: [],
+      first_seen: now.toISOString(),
+      last_updated: now.toISOString(),
+      duration_ms: 100,
+      events: [
+        createMockEvent(callback_id, 'tasks.aggregate', 'PENDING', {
+          parent_id: `group:${group_id}`,
+          root_id: `group:${group_id}`,
+        }),
+        createMockEvent(callback_id, 'tasks.aggregate', 'SUCCESS', {
+          parent_id: `group:${group_id}`,
+          root_id: `group:${group_id}`,
+          result: { total: memberCount * 2 },
+        }),
+      ],
+    }
+    // Each member points to callback
+    for (const member of members) {
+      member.children.push(callback_id)
+    }
+    allTasks.push(callback)
+  }
+
+  return allTasks
+}
+
+/**
+ * Create a workflow: parent task spawns a group
+ */
+export function createWorkflowWithGroup(memberCount: number): MockTask[] {
+  const parent_id = generateTaskId()
+  const group_id = generateTaskId()
+  const now = new Date()
+  const startTime = new Date(now.getTime() - 3000)
+
+  const parent: MockTask = {
+    task_id: parent_id,
+    name: 'tasks.batch_processor',
+    state: 'SUCCESS',
+    parent_id: null,
+    root_id: parent_id,
+    node_type: 'TASK',
+    group_id: null,
+    chord_id: null,
+    children: [`group:${group_id}`],
+    first_seen: startTime.toISOString(),
+    last_updated: now.toISOString(),
+    duration_ms: 3000,
+    events: [
+      createMockEvent(parent_id, 'tasks.batch_processor', 'PENDING'),
+      createMockEvent(parent_id, 'tasks.batch_processor', 'SUCCESS', {
+        result: { items: memberCount },
+      }),
+    ],
+  }
+
+  const groupNode: MockTask = {
+    task_id: `group:${group_id}`,
+    name: `group:${group_id.slice(0, 8)}`,
+    state: 'SUCCESS',
+    parent_id: parent_id,
+    root_id: parent_id,
+    node_type: 'GROUP',
+    group_id,
+    chord_id: null,
+    children: [],
+    first_seen: startTime.toISOString(),
+    last_updated: now.toISOString(),
+    duration_ms: 2000,
+    events: [],
+  }
+
+  const members: MockTask[] = []
+  for (let i = 0; i < memberCount; i++) {
+    const task_id = generateTaskId()
+    const task: MockTask = {
+      task_id,
+      name: 'tasks.process_item',
+      state: 'SUCCESS',
+      parent_id: parent_id,
+      root_id: parent_id,
+      node_type: 'TASK',
+      group_id,
+      chord_id: null,
+      children: [],
+      first_seen: startTime.toISOString(),
+      last_updated: now.toISOString(),
+      duration_ms: 500,
+      events: [
+        createMockEvent(task_id, 'tasks.process_item', 'PENDING', {
+          parent_id,
+          root_id: parent_id,
+          group_id,
+          args: [i],
+        }),
+        createMockEvent(task_id, 'tasks.process_item', 'SUCCESS', {
+          parent_id,
+          root_id: parent_id,
+          group_id,
+          result: i * 2,
+        }),
+      ],
+    }
+    members.push(task)
+    groupNode.children.push(task_id)
+  }
+
+  return [parent, groupNode, ...members]
+}
+
+/**
+ * Default mock data set for tests
+ */
+export const DEFAULT_TASKS: MockTask[] = [
+  createSuccessTask('tasks.add', 5),
+  createSuccessTask('tasks.multiply', 20),
+  createFailedTask(
+    'tasks.always_fails',
+    'ValueError: Intentional failure',
+    'Traceback (most recent call last):\n  File "tasks.py", line 42\n    raise ValueError("Intentional failure")\nValueError: Intentional failure',
+  ),
+  ...createChain('tasks.workflow', 3),
+  ...createGroup(3, { withCallback: true }),
+  ...createWorkflowWithGroup(2),
+]
+
+/**
+ * Registry mock data
+ */
+export const DEFAULT_REGISTRY = [
+  {
+    name: 'tasks.add',
+    signature: '(x, y)',
+    docstring: 'Add two numbers together.',
+    module: 'tasks',
+    bound: false,
+  },
+  {
+    name: 'tasks.multiply',
+    signature: '(x, y)',
+    docstring: 'Multiply two numbers together.',
+    module: 'tasks',
+    bound: false,
+  },
+  {
+    name: 'tasks.process_item',
+    signature: '(item_id)',
+    docstring: 'Process a single item.',
+    module: 'tasks',
+    bound: false,
+  },
+  {
+    name: 'tasks.aggregate',
+    signature: '(items)',
+    docstring: 'Aggregate multiple items.',
+    module: 'tasks',
+    bound: false,
+  },
+  {
+    name: 'tasks.batch_processor',
+    signature: '(batch)',
+    docstring: 'Process a batch of items.',
+    module: 'tasks',
+    bound: false,
+  },
+  {
+    name: 'tasks.always_fails',
+    signature: '()',
+    docstring: 'A task that always fails.',
+    module: 'tasks',
+    bound: false,
+  },
+]


### PR DESCRIPTION
Adds mock-based Playwright E2E testing that doesn't require Docker.

## Changes
- Add mock API fixtures for Playwright tests
- Configure dual-mode: mock (default) and real (Docker)
- Add e2e-mock and e2e-quick Makefile targets

## Usage
```bash
make e2e-mock    # Run mock E2E tests (no Docker)
make e2e         # Run real E2E tests (requires Docker)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added mock mode for E2E tests to run without Docker dependencies.
  * Tests now use mock API by default; real Docker backend mode available via environment variable.
  * Expanded test coverage with new mock scenarios for graphs, registry, and task detail pages.

* **Chores**
  * Updated test infrastructure with new test execution targets and enhanced Playwright configuration for flexible test modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->