### PR TITLE
docs: add release version badge

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -31,3 +31,9 @@ search = "## [Unreleased]"
 replace = """## [Unreleased]
 
 ## [{new_version}] - {now:%Y-%m-%d}"""
+
+# README.md - keep Release badge in sync with version (avoid cached badge drift)
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "[![Release](https://img.shields.io/badge/release-v{current_version}-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v{current_version})"
+replace = "[![Release](https://img.shields.io/badge/release-v{new_version}-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v{new_version})"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Zero-infrastructure Celery task flow visualizer**
 
+[![Release](https://img.shields.io/badge/release-v0.2.1-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v0.2.1)
 [![PyPI version](https://img.shields.io/pypi/v/stemtrace?color=darklime)](https://pypi.org/project/stemtrace)
 [![Python](https://img.shields.io/pypi/pyversions/stemtrace.svg)](https://pypi.org/project/stemtrace/)
 [![CI](https://github.com/iansokolskyi/stemtrace/actions/workflows/ci.yml/badge.svg)](https://github.com/iansokolskyi/stemtrace/actions/workflows/ci.yml)


### PR DESCRIPTION
## Why

GitHub README badges are served via Camo and can be cached for hours, causing the displayed version to lag right after a release.

## Changes

- Add a static Release badge whose URL encodes the current version (cache-proof)
- Wire the badge into bump-my-version so it updates automatically on every bump

## Result

- GitHub and PyPI will show the new version immediately after a bump/release commit
- The dynamic PyPI badge may still lag briefly, but the Release badge stays correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Release badge to README.md to prominently display the current version.

* **Chores**
  * Enhanced release automation to synchronize version references in documentation during release workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->