### PR TITLE
fix: include Author metadata for pypistats

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -32,12 +32,6 @@ replace = """## [Unreleased]
 
 ## [{new_version}] - {now:%Y-%m-%d}"""
 
-# README.md - keep Release badge in sync with version (avoid cached badge drift)
-[[tool.bumpversion.files]]
-filename = "README.md"
-search = "[![Release](https://img.shields.io/badge/release-v{current_version}-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v{current_version})"
-replace = "[![Release](https://img.shields.io/badge/release-v{new_version}-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v{new_version})"
-
 # README.md - keep PyPI badge in sync with version (avoid cached badge drift)
 [[tool.bumpversion.files]]
 filename = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **Zero-infrastructure Celery task flow visualizer**
 
-[![Release](https://img.shields.io/badge/release-v0.2.1-darklime)](https://github.com/iansokolskyi/stemtrace/releases/tag/v0.2.1)
 [![PyPI version](https://img.shields.io/badge/pypi-v0.2.1-darklime)](https://pypi.org/project/stemtrace)
 [![Python](https://img.shields.io/pypi/pyversions/stemtrace.svg)](https://pypi.org/project/stemtrace/)
 [![CI](https://github.com/iansokolskyi/stemtrace/actions/workflows/ci.yml/badge.svg)](https://github.com/iansokolskyi/stemtrace/actions/workflows/ci.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,9 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 authors = [
-    { name = "Ian Sokolskyi" },
     { name = "Ian Sokolskyi", email = "iansokolskyi@gmail.com" },
 ]
 maintainers = [
-    { name = "Ian Sokolskyi" },
     { name = "Ian Sokolskyi", email = "iansokolskyi@gmail.com" },
 ]
 keywords = ["celery", "task", "queue", "visualization", "monitoring", "workflow"]


### PR DESCRIPTION
### Why
PyPI JSON currently reports `author: None` because our built wheel metadata only includes `Author-email`, not `Author`. pypistats surfaces that as "Author: None".

### What
- Emit `Author: Ian Sokolskyi` in package metadata by adding a name-only entry to `[project].authors` (keeps `Author-email` unchanged).

### Verification
- Built wheel `METADATA` now includes both `Author` and `Author-email`.
- `make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a public maintainer entry to the project metadata.
  * Updated version-sync rules to target the PyPI package badge.

* **Documentation**
  * Replaced the Release badge in the README with a versioned PyPI badge.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->