### PR TITLE
fix: order task nodes before synthetic container nodes for correct graph

### DIFF
--- a/src/stemtrace/server/api/routes.py
+++ b/src/stemtrace/server/api/routes.py
@@ -159,6 +159,16 @@ def _node_to_graph_response(
     if first_seen and last_updated and first_seen != last_updated:
         duration_ms = int((last_updated - first_seen).total_seconds() * 1000)
 
+    # UI traversal is order-sensitive when callbacks can appear as both direct
+    # children and CHORD-linked nodes. Prefer TASK children first so callback
+    # branches render before synthetic containers.
+    children = node.children
+    if all_nodes is not None:
+        children = sorted(
+            node.children,
+            key=lambda c: getattr(all_nodes.get(c), "node_type", None) != "TASK",
+        )
+
     return GraphNodeResponse(
         task_id=node.task_id,
         name=node.name,
@@ -167,7 +177,7 @@ def _node_to_graph_response(
         group_id=node.group_id,
         chord_id=node.chord_id,
         parent_id=node.parent_id,
-        children=node.children,
+        children=children,
         duration_ms=duration_ms,
         first_seen=first_seen,
         last_updated=last_updated,

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1184,3 +1184,55 @@ class TestGraphNodeTimingResponse:
         assert resp.first_seen == t1
         assert resp.last_updated == t2
         assert resp.duration_ms == int((t2 - t1).total_seconds() * 1000)
+
+    def test_graph_node_response_children_sorted_tasks_first(self) -> None:
+        """Children are ordered with TASK nodes first, GROUP/CHORD nodes last."""
+        t0 = datetime(2024, 1, 1, tzinfo=UTC)
+
+        task_a = TaskNode(
+            task_id="task-a",
+            name="myapp.tasks.a",
+            state=TaskState.SUCCESS,
+            events=[
+                TaskEvent(
+                    task_id="task-a",
+                    name="myapp.tasks.a",
+                    state=TaskState.SUCCESS,
+                    timestamp=t0,
+                )
+            ],
+        )
+        task_b = TaskNode(
+            task_id="task-b",
+            name="myapp.tasks.b",
+            state=TaskState.SUCCESS,
+            events=[
+                TaskEvent(
+                    task_id="task-b",
+                    name="myapp.tasks.b",
+                    state=TaskState.SUCCESS,
+                    timestamp=t0,
+                )
+            ],
+        )
+        chord_node = TaskNode(
+            task_id="group:chord-1",
+            name="chord",
+            state=TaskState.SUCCESS,
+            node_type=NodeType.CHORD,
+            children=[],
+        )
+
+        # Parent has children in "wrong" order: chord first, then tasks
+        parent = TaskNode(
+            task_id="root",
+            name="myapp.tasks.process_uploads",
+            state=TaskState.SUCCESS,
+            node_type=NodeType.TASK,
+            children=["group:chord-1", "task-a", "task-b"],
+        )
+
+        all_nodes = {"task-a": task_a, "task-b": task_b, "group:chord-1": chord_node}
+        resp = routes._node_to_graph_response(parent, all_nodes=all_nodes)
+
+        assert resp.children == ["task-a", "task-b", "group:chord-1"]


### PR DESCRIPTION
https://github.com/iansokolskyi/stemtrace/issues/53
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display order of child nodes in the graph interface to prioritize task nodes, ensuring they render before group or chord nodes for better user navigation.

* **Tests**
  * Added unit test to validate the correct sorting behavior of graph node children.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->